### PR TITLE
Improving the testing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,13 @@ The `npm run` supports the following commands.
 - **precompile** Automatically run before `compile`. Runs `clean`.
 - **compile** Compiles the TypeScript.
 - **coveralls** Sends code coverage information to Coveralls.
-- **prelint** Automatically run before `lint`. Runs `compile` with `sourceMaps` 
-  this is both for `test` and to make sure any custom lint rules will be
-  compiled.
 - **lint** Runs `tslint` on all of the files.
-- **pretest** Automatically run before `test`. Runs `lint` and modifies the
+- **pretest** Automatically run before `test`. Compiles and modifies the
   compiled JavaScript for sourcemap support and coverage.
 - **test** Runs mocha with istanbul code coverage. Set `$MOCHA_REPORTER` to
   override which reporter is used in tests.
 - **posttest** Automatically run after `test`. Checks the code coverage and will
-  fail if the code coverage is not sufficient.
+  fail if the code coverage is not sufficient. Also runs `lint`.
 - **typings** Installs the type definitions.
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -18,11 +18,10 @@
     "precompile": "npm run clean",
     "compile": "find src test typings -name \"*.ts\" | xargs tsc --declaration --module commonjs --target es5 --noImplicitAny --outDir build",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "prelint": "npm run compile -- --sourceMap",
     "lint": "find src test -name \"*.ts\" | sed 's/^/--file=/g' | xargs tslint",
-    "pretest": "npm run lint && find build -type f -name *.js -exec sed -i .bak -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/; 1s/^/require(\"source-map-support\").install();\r/' {} \\;",
+    "pretest": "npm run compile -- --sourceMap && find build -type f -name *.js -exec sed -i .bak -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/; 1s/^/require(\"source-map-support\").install();\r/' {} \\;",
     "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --recursive build/**/*_test.js",
-    "posttest": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
+    "posttest": "npm run lint && istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "typings": "tsd reinstall && tsd rebundle"
   },
   "repository": {

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -15,4 +15,9 @@ suite("Index", () => {
         chai.assert.instanceOf(child, index.Parent);
         chai.assert.instanceOf(child, index.Child);
     });
+
+    test.skip("sourcemaps", () => {
+        // Tests that sourcemaps work
+        throw new Error("test");
+    });
 });


### PR DESCRIPTION
This makes it easier to see if tests are passing before failing on lint
errors.