### PR TITLE
Fix sed in-place flag syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "find src test -name \"*.ts\" | sed 's/^/--file=/g' | xargs tslint",
     "setup": "rm -rf node_modules typings && npm install && npm run typings",
-    "pretest": "npm run compile -- --sourceMap && find build -type f -name *.js -exec sed -i .bak -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/; 1s/^/require(\"source-map-support\").install();\r/' {} \\;",
+    "pretest": "npm run compile -- --sourceMap && find build -type f -name *.js -exec sed -i'.bak' -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/; 1s/^/require(\"source-map-support\").install();\r/' {} \\;",
     "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --recursive build/**/*_test.js --full-trace",
     "posttest": "npm run lint && istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "typings": "tsd reinstall && tsd rebundle",


### PR DESCRIPTION
The space between `-i` and `.bak` was causing different commands in lunadb-web-client to fail. This doesn't seem to have caused a problem in typescript-starter, but we should make the example use of `sed` work if you copy-paste it.