### PR TITLE
Removing source maps

### DIFF
--- a/.tsdrc
+++ b/.tsdrc
@@ -1,0 +1,3 @@
+{
+  "token": "9ad3f29b6efee19ca0ae949289bade33f537d845"
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "find src test -name \"*.ts\" | sed 's/^/--file=/g' | xargs tslint",
     "setup": "rm -rf node_modules typings && npm install && npm run typings",
-    "pretest": "npm run compile -- --sourceMap && find build -type f -name *.js -exec sed -i'.bak' -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/; 1s/^/require(\"source-map-support\").install();\r/' {} \\;",
+    "pretest": "npm run compile && find build -type f -name *.js -exec sed -i'.bak' -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/;' {} \\;",
     "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --recursive build/**/*_test.js --full-trace",
     "posttest": "npm run lint && istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "typings": "tsd reinstall && tsd rebundle",
@@ -46,7 +46,6 @@
     "istanbul": "^0.3.14",
     "mocha": "^2.2.4",
     "sinon": "^1.14.1",
-    "source-map-support": "^0.2.10",
     "tsd": "^0.6.0-beta.5",
     "tslint": "^2.1.1",
     "typescript": "^1.4.1"

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -15,9 +15,4 @@ suite("Index", () => {
         chai.assert.instanceOf(child, index.Parent);
         chai.assert.instanceOf(child, index.Child);
     });
-
-    test.skip("sourcemaps", () => {
-        // Tests that sourcemaps work
-        throw new Error("test");
-    });
 });


### PR DESCRIPTION
The source maps make things more confusing and are not helpful. We
should create a new library with better source-map-support