### PR TITLE
Adding back sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "files": [
     "typescript-starter.d.ts",
     "**/*.js",
+    "**/*.js.map",
     "!**/*_test.js",
+    "!**/*_test.js.map",
     "!build/**/*.js",
     "!coverage/**/*.js",
     "!node_modules/**/*.js"
@@ -16,12 +18,12 @@
     "bundle": "dts-generator --name $npm_package_name --main ${npm_package_name}/index --baseDir . --exclude node_modules/dts-generator/node_modules/typescript/bin/lib.es6.d.ts -out ${npm_package_name}.d.ts *.d.ts",
     "clean": "rm -rf build coverage",
     "precompile": "npm run clean",
-    "compile": "find src test typings -name \"*.ts\" | xargs tsc --declaration --module commonjs --target es5 --noImplicitAny --outDir build",
+    "compile": "find src test typings -name \"*.ts\" | xargs tsc --declaration --module commonjs --target es5 --noImplicitAny --sourceMap --outDir build",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "find src test -name \"*.ts\" | sed 's/^/--file=/g' | xargs tslint",
     "setup": "git clean -xdf && npm install && npm run typings",
     "pretest": "npm run compile && find build -type f -name *.js -exec sed -i'.bak' -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/;' {} \\;",
-    "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --recursive build/**/*_test.js --full-trace",
+    "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --full-trace --require source-map-support/register --recursive build/**/*_test.js ",
     "posttest": "npm run lint && istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "typings": "tsd reinstall && tsd rebundle",
     "update": "git fetch && git merge origin master && npm run setup"
@@ -46,6 +48,7 @@
     "istanbul": "^0.3.14",
     "mocha": "^2.2.4",
     "sinon": "^1.14.1",
+    "source-map-support": "^0.3.1",
     "tsd": "^0.6.0-beta.5",
     "tslint": "^2.1.1",
     "typescript": "^1.4.1"

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -15,4 +15,8 @@ suite("Index", () => {
         chai.assert.instanceOf(child, index.Parent);
         chai.assert.instanceOf(child, index.Child);
     });
+
+    test("sourcemaps", () => {
+        throw new Error("sourcemaps!!!");
+    });
 });

--- a/test/index_test.ts
+++ b/test/index_test.ts
@@ -16,7 +16,7 @@ suite("Index", () => {
         chai.assert.instanceOf(child, index.Child);
     });
 
-    test("sourcemaps", () => {
+    test.skip("sourcemaps", () => {
         throw new Error("sourcemaps!!!");
     });
 });


### PR DESCRIPTION
The new version seems to have fixed the problem. I do feel like it is
worth potentially writing our own though.

Inspired by https://github.com/evanw/node-source-map-support/issues/60#issuecomment-107067009