### PR TITLE
Configuration updates to make it friendlier for first timers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build
 *.d.ts
 *.js
 typings
+
+# Personal TSD config (GitHub API Token goes here)
+.tsdrc

--- a/.tsdrc
+++ b/.tsdrc
@@ -1,3 +1,0 @@
-{
-  "token": "9ad3f29b6efee19ca0ae949289bade33f537d845"
-}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ changes can be merged in. The developer should replace all instances of
 `typescript-starter` with their package name and change the appropriate fields
 in the `package.json`.
 
+## Setup
+
+Create a `.tsdrc` file in the directory with a GitHub API token.  A personal 
+access can be generated at [Settings > Personal access tokens](https://github.com/settings/tokens).
+This token is used by TSD to access type definitions for libraries like mocha.
+
 ## Commands
 
 The default is to use simple npm scripts instead of `gulp` or `grunt` because

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "precompile": "npm run clean",
     "compile": "find src test typings -name \"*.ts\" | xargs tsc --declaration --module commonjs --target es5 --noImplicitAny --sourceMap --outDir build",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "lint": "find src test -name \"*.ts\" | sed 's/^/--file=/g' | xargs tslint",
+    "lint": "find src test -name \"*.ts\" | xargs tslint",
     "setup": "git clean -xdf && npm install && npm run typings",
     "pretest": "npm run compile && find build -type f -name *.js -exec sed -i'.bak' -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/;' {} \\;",
     "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --full-trace --require source-map-support/register --recursive build/**/*_test.js ",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "lint": "find src test -name \"*.ts\" | xargs tslint",
     "setup": "git clean -xdf && npm install && npm run typings",
-    "pretest": "npm run compile && find build -type f -name *.js -exec sed -i'.bak' -e '1s/^var __extends/\\/\\* istanbul ignore next \\*\\/\rvar __extends/;' {} \\;",
+    "pretest": "npm run compile && find build -type f -name *.js -exec perl -i.bak -pe '$_ = qq[/* istanbul ignore next*/\n$_] if $_ =~ /var __extend/ and $. <=2' {} \\;",
     "test": "istanbul cover _mocha -- --reporter ${MOCHA_REPORTER-nyan} --slow 10 --ui tdd --full-trace --require source-map-support/register --recursive build/**/*_test.js ",
     "posttest": "npm run lint && istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "typings": "tsd reinstall && tsd rebundle",


### PR DESCRIPTION
Hey Phips! Thanks for making this.  I am making my first foray into Typescript and figured this would be a good place to start.

I downloaded the repo and attempted to the sanity check.  I ran into a couple issues.


### API Token
The first issue I had was getting back 401's from the github API.  I figured out the .tsdrc file was causing the issue, so I added my token (and added some lines to the README).

```
-> running reinstall
[ERR!] cwd  : /Users/paul/space/ts-scratch
[ERR!] os   : Darwin 14.5.0
[ERR!] argv : "/usr/local/bin/node" "/ts-scratch/node_modules/.bin/tsd" "reinstall"
[ERR!] node : v5.2.0
[ERR!] tsd  : 0.6.5
[ERR!] Error: unexpected status code: 401 on: https://api.github.com/repos/Asana/DefinitelyTyped/branches/master
[ERR!] CODE : undefined
[ERR!] unexpected status code: 401 on: https://api.github.com/repos/Asana/DefinitelyTyped/branches/master
[ERR!] If you need help, you may report this error at:
    https://github.com/DefinitelyTyped/tsd/issues
```

### tslint
The next issue I bumped into was a complaint from tslint.
```
> typescript-starter@0.0.1 lint /Users/paul/space/ts-scratch
> find src test -name "*.ts" | sed 's/^/--file=/g' | xargs tslint

Usage: /usr/local/bin/node ./node_modules/.bin/tslint [options] [file ...]

Options:
  -c, --config          configuration file
  -h, --help            display detailed help
  -o, --out             output file
  -r, --rules-dir       rules directory
  -s, --formatters-dir  formatters directory
  -t, --format          output format (prose, json, verbose)  [default: "prose"]
  -v, --version         current version

Missing files
```
Npm installed version 2.5.1
```
%> ./node_modules/tslint/bin/tslint --version
2.5.1
```
I removed the "--file=" prefix to fix this one.

### istanbul coverage
The final issue I was having was that Istanbul was reporting 57% test coverage:
```
> typescript-starter@0.0.1 posttest /Users/paul/space/ts-scratch
> npm run lint && istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100


> typescript-starter@0.0.1 lint /Users/paul/space/ts-scratch
> find src test -name "*.ts" | xargs tslint


/Users/paul/space/ts-scratch/node_modules/istanbul/lib/cli.js:38
        throw ex; // turn it into an uncaught exception
        ^
ERROR: Coverage for statements (88.89%) does not meet global threshold (100%)
ERROR: Coverage for branches (57.14%) does not meet global threshold (100%)
npm ERR! Test failed.  See above for more details.
```

I discovered that the `sed` command used to insert the istanbul ignore comments wasn't working properly for me.  It was looking on the first line for the pattern, but the first line in my index.js was `"use strict";`.  I changed this up to check the second line.  I also changed it to use perl because I couldn't wrestle `sed` into inserting a newline.


I'm also new to PR's, so let me know if this is totally the wrong format or avenue to send this to you.
